### PR TITLE
Add interactive map to graffiti explorer

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
   <title>Phiti Graffiti Explorer</title>
   <link rel="stylesheet" href="styles.css"/>
   <link rel="icon" href="phiti_logo.png"/>
+  <!-- Leaflet CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <!-- Leaflet MarkerCluster CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"/>
 </head>
 <body>
   <header>
@@ -37,6 +42,10 @@
     </div>
     <button id="randomBtn" title="Show a random tag">🎲 Random</button>
     <button id="clearBtn" title="Clear all filters">✕ Clear</button>
+    <div class="view-toggle">
+      <button id="galleryViewBtn" class="view-btn active" title="Gallery View">🖼️ Gallery</button>
+      <button id="mapViewBtn" class="view-btn" title="Map View">🗺️ Map</button>
+    </div>
   </section>
 
   <div id="results-info">
@@ -45,6 +54,21 @@
 
   <main>
     <section id="gallery"></section>
+    <section id="map-container" class="hidden">
+      <div id="map"></div>
+      <div id="map-controls">
+        <button id="clusterModeBtn" class="map-mode-btn active" title="Cluster View">📍 Clusters</button>
+        <button id="heatModeBtn" class="map-mode-btn" title="Heatmap View">🔥 Heatmap</button>
+      </div>
+      <div id="map-legend">
+        <div class="legend-title">Graffiti Density</div>
+        <div class="legend-gradient"></div>
+        <div class="legend-labels">
+          <span>Low</span>
+          <span>High</span>
+        </div>
+      </div>
+    </section>
     <div id="loader" class="hidden"><span class="spinner"></span> Loading Graffiti...</div>
   </main>
 
@@ -59,6 +83,12 @@
     <button id="lightbox-close" title="Close">&times;</button>
   </div>
 
+  <!-- Leaflet JS -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <!-- Leaflet MarkerCluster JS -->
+  <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+  <!-- Leaflet Heat JS -->
+  <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"></script>
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -433,3 +433,420 @@ footer a:hover {
     max-height: 60vh;
   }
 }
+
+/* ============================================
+   MAP VIEW STYLES
+   ============================================ */
+
+/* View Toggle Buttons */
+.view-toggle {
+  display: flex;
+  gap: 0;
+  margin-left: 0.5rem;
+}
+
+.view-btn {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.95rem;
+  background: var(--surface);
+  color: var(--text);
+  border: 2px solid var(--street);
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.view-btn:first-child {
+  border-radius: 50px 0 0 50px;
+  border-right: 1px solid var(--street);
+}
+
+.view-btn:last-child {
+  border-radius: 0 50px 50px 0;
+  border-left: 1px solid var(--street);
+}
+
+.view-btn:hover {
+  background: var(--street);
+  color: #fff;
+}
+
+.view-btn.active {
+  background: var(--accent);
+  color: #181818;
+  border-color: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+}
+
+.view-btn:focus {
+  outline: 3px solid var(--tag);
+}
+
+/* Map Container */
+#map-container {
+  width: 100%;
+  max-width: 1320px;
+  margin: 0 auto;
+  position: relative;
+}
+
+#map-container.hidden {
+  display: none;
+}
+
+#map {
+  width: 100%;
+  height: 70vh;
+  min-height: 500px;
+  border-radius: 14px;
+  border: 3px solid var(--accent2);
+  box-shadow: 0 8px 40px #000a, 0 0 20px var(--accent2);
+  background: var(--bg);
+}
+
+/* Map Controls */
+#map-controls {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  z-index: 1000;
+  display: flex;
+  gap: 0;
+  background: var(--surface);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 15px #000a;
+  border: 2px solid var(--street);
+}
+
+.map-mode-btn {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.9rem;
+  background: var(--surface);
+  color: var(--text);
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.map-mode-btn:first-child {
+  border-right: 1px solid var(--street);
+}
+
+.map-mode-btn:hover {
+  background: var(--street);
+}
+
+.map-mode-btn.active {
+  background: var(--accent2);
+  color: #fff;
+  text-shadow: 0 1px 3px #0008;
+}
+
+.map-mode-btn:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Map Legend */
+#map-legend {
+  position: absolute;
+  bottom: 25px;
+  left: 15px;
+  z-index: 1000;
+  background: rgba(41, 43, 47, 0.95);
+  border-radius: 8px;
+  padding: 0.8rem 1rem;
+  box-shadow: 0 4px 15px #000a;
+  border: 2px solid var(--street);
+  display: none;
+}
+
+#map-legend.visible {
+  display: block;
+}
+
+.legend-title {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.85rem;
+  color: var(--tag);
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.legend-gradient {
+  width: 120px;
+  height: 12px;
+  background: linear-gradient(90deg,
+    rgba(86, 227, 86, 0.3) 0%,
+    rgba(230, 230, 55, 0.6) 33%,
+    rgba(245, 55, 83, 0.8) 66%,
+    rgba(245, 55, 83, 1) 100%
+  );
+  border-radius: 4px;
+  margin-bottom: 0.3rem;
+}
+
+.legend-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--text);
+  opacity: 0.8;
+}
+
+/* Custom Marker Cluster Styling */
+.marker-cluster {
+  background: transparent !important;
+}
+
+.marker-cluster div {
+  background: linear-gradient(135deg, var(--accent2) 0%, var(--tag) 100%);
+  color: #181818;
+  font-family: 'Permanent Marker', cursive;
+  font-weight: bold;
+  text-align: center;
+  border-radius: 50%;
+  box-shadow: 0 3px 12px #000a, 0 0 8px var(--accent2);
+  border: 2px solid #fff;
+}
+
+.marker-cluster-small {
+  background: transparent !important;
+}
+.marker-cluster-small div {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  font-size: 0.8rem;
+  background: linear-gradient(135deg, var(--accent) 0%, #3bb33b 100%) !important;
+}
+
+.marker-cluster-medium {
+  background: transparent !important;
+}
+.marker-cluster-medium div {
+  width: 42px;
+  height: 42px;
+  line-height: 42px;
+  font-size: 0.9rem;
+  background: linear-gradient(135deg, var(--tag) 0%, #c9c920 100%) !important;
+}
+
+.marker-cluster-large {
+  background: transparent !important;
+}
+.marker-cluster-large div {
+  width: 52px;
+  height: 52px;
+  line-height: 52px;
+  font-size: 1rem;
+  background: linear-gradient(135deg, var(--accent2) 0%, #d42a45 100%) !important;
+  color: #fff !important;
+}
+
+/* Custom single marker */
+.graffiti-marker {
+  background: var(--accent);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 2px 8px #000a, 0 0 6px var(--accent);
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.graffiti-marker:hover {
+  transform: scale(1.3);
+  box-shadow: 0 3px 12px #000a, 0 0 12px var(--tag);
+}
+
+/* Custom Popup Styling */
+.leaflet-popup-content-wrapper {
+  background: linear-gradient(135deg, #23252a 0%, #353941 100%);
+  color: var(--text);
+  border-radius: 12px;
+  box-shadow: 0 6px 25px #000a, 0 0 15px var(--accent2);
+  border: 2px solid var(--tag);
+  padding: 0;
+  overflow: hidden;
+}
+
+.leaflet-popup-content {
+  margin: 0;
+  min-width: 250px;
+  max-width: 300px;
+}
+
+.leaflet-popup-tip {
+  background: var(--tag);
+  box-shadow: 0 3px 10px #0008;
+}
+
+.leaflet-popup-close-button {
+  color: var(--text) !important;
+  font-size: 1.4rem !important;
+  padding: 8px 10px !important;
+  transition: color 0.15s;
+}
+
+.leaflet-popup-close-button:hover {
+  color: var(--accent2) !important;
+}
+
+/* Popup Content */
+.popup-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.popup-img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-bottom: 2px solid var(--tag);
+  cursor: pointer;
+  transition: filter 0.2s;
+}
+
+.popup-img:hover {
+  filter: brightness(1.1);
+}
+
+.popup-info {
+  padding: 0.8rem;
+}
+
+.popup-address {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.95rem;
+  color: var(--accent);
+  margin-bottom: 0.4rem;
+  word-break: break-word;
+}
+
+.popup-area {
+  display: inline-block;
+  background: var(--street);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+  margin-left: 0.3em;
+}
+
+.popup-meta {
+  font-size: 0.85rem;
+  color: #aaa;
+  margin: 0.25rem 0;
+}
+
+.popup-meta strong {
+  color: var(--accent2);
+}
+
+.popup-status {
+  font-weight: 600;
+  color: var(--tag);
+}
+
+.popup-view-btn {
+  display: block;
+  width: 100%;
+  margin-top: 0.6rem;
+  padding: 0.5rem;
+  font-family: 'Permanent Marker', cursive;
+  font-size: 0.9rem;
+  background: var(--accent2);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: center;
+}
+
+.popup-view-btn:hover {
+  background: var(--tag);
+  color: #181818;
+  transform: scale(1.02);
+}
+
+/* Dark map tiles adjustment */
+.leaflet-container {
+  background: var(--bg);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Leaflet controls dark theme */
+.leaflet-control-zoom a {
+  background: var(--surface) !important;
+  color: var(--text) !important;
+  border-color: var(--street) !important;
+}
+
+.leaflet-control-zoom a:hover {
+  background: var(--street) !important;
+  color: #fff !important;
+}
+
+.leaflet-control-attribution {
+  background: rgba(41, 43, 47, 0.85) !important;
+  color: #888 !important;
+}
+
+.leaflet-control-attribution a {
+  color: var(--accent) !important;
+}
+
+/* Map responsive */
+@media (max-width: 600px) {
+  .view-toggle {
+    width: 100%;
+    justify-content: center;
+    margin-left: 0;
+    margin-top: 0.5rem;
+  }
+
+  .view-btn {
+    flex: 1;
+    text-align: center;
+  }
+
+  #map {
+    height: 60vh;
+    min-height: 400px;
+    border-radius: 10px;
+  }
+
+  #map-controls {
+    top: 10px;
+    right: 10px;
+  }
+
+  .map-mode-btn {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.7rem;
+  }
+
+  #map-legend {
+    bottom: 15px;
+    left: 10px;
+    padding: 0.6rem 0.8rem;
+  }
+
+  .legend-gradient {
+    width: 90px;
+  }
+
+  .leaflet-popup-content {
+    min-width: 200px;
+    max-width: 250px;
+  }
+
+  .popup-img {
+    height: 120px;
+  }
+}


### PR DESCRIPTION
Implement a full-featured map view for exploring graffiti locations:
- Toggle between Gallery and Map views
- Cluster mode groups nearby markers with custom themed styling
- Heatmap mode shows density visualization of graffiti hotspots
- Click markers to see popup with image, address, and details
- Full integration with existing filters (area, status, zipcode, year, search)
- Dark-themed CartoDB tiles matching the urban aesthetic
- Custom marker icons and popups matching the graffiti theme
- Legend for heatmap gradient interpretation
- Responsive design for mobile devices